### PR TITLE
Fix output path for backend client generation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,8 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "gen": "encore gen client next-js-test-ts-9wvi --output=./frontend/app/lib/client.ts --env=staging",
-    "gen:local": "encore gen client next-js-test-ts-9wvi --output=./frontend/app/lib/client.ts --env=local"
+    "gen": "encore gen client next-js-test-ts-9wvi --output=../frontend/app/lib/client.ts --env=staging",
+    "gen:local": "encore gen client next-js-test-ts-9wvi --output=../frontend/app/lib/client.ts --env=local"
   },
   "devDependencies": {
     "typescript": "^5.2.2",


### PR DESCRIPTION
  * If you run the gen:local as is, it won't find the frontend directory because it will look relative to the backend/package.json and backend/frontend/app/lib... etc is not a real path. Instead let's step backwards one directory, and then step into the frontend This makes it work for me. I tested with a completely new repo, following the steps, and the gen client step did not work for me without this change.